### PR TITLE
修复拍照按钮在特殊情况下出现的事件处理bug

### DIFF
--- a/camera/src/main/java/com/cjt2325/cameralibrary/CaptureButton.java
+++ b/camera/src/main/java/com/cjt2325/cameralibrary/CaptureButton.java
@@ -76,6 +76,7 @@ public class CaptureButton extends View {
 
     //按钮回调接口
     private CaptureLisenter captureLisenter;
+    private boolean hasWindowFocus = true;
 
     public CaptureButton(Context context) {
         super(context);
@@ -219,6 +220,15 @@ public class CaptureButton extends View {
     private class RecordRunnable implements Runnable {
         @Override
         public void run() {
+            if (!hasWindowFocus){
+                //移除录制视频的Runnable
+                removeCallbacks(recordRunnable);
+                resetRecordAnim();
+                //制空当前状态
+                state = STATE_NULL;
+                return;
+            }
+
             record_anim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
                 @Override
                 public void onAnimationUpdate(ValueAnimator animation) {
@@ -245,6 +255,13 @@ public class CaptureButton extends View {
         }
     }
 
+
+    @Override
+    public void onWindowFocusChanged(boolean hasWindowFocus) {
+        super.onWindowFocusChanged(hasWindowFocus);
+        this.hasWindowFocus = hasWindowFocus;
+    }
+
     /**
      * 录制结束
      * @param finish 是否录制满时间
@@ -263,6 +280,10 @@ public class CaptureButton extends View {
                 }
             }
         }
+        resetRecordAnim();
+    }
+
+    private void resetRecordAnim() {
         //取消动画
         record_anim.cancel();
         //重制进度


### PR DESCRIPTION
问题：在6.0一下手机中长按开始录视频，会有询问语音权限的对话框弹出，此时，点击允许后，手指已经离开屏幕，但是依然在继续录影
分析：长按按钮后，出现了权限询问对话框，此时，但是按钮失去了焦点，检测不到up事件，允许权限后，录影任务已经开始。
解决：应该在长按任务中判断，按钮此刻是否有焦点，如果没有，应该移除录影任务，并且恢复按钮的初始状态